### PR TITLE
no interactive login with --force flag

### DIFF
--- a/lib/cf/cli.rb
+++ b/lib/cf/cli.rb
@@ -122,9 +122,11 @@ module CF
         line
         line c("Not authenticated! Try logging in:", :warning)
 
-        # TODO: there's no color here; global flags not being passed
-        # through (mothership bug?)
-        invoke :login
+        if !force?
+          # TODO: there's no color here; global flags not being passed
+          # through (mothership bug?)
+          invoke :login
+        end
 
         retry
       end

--- a/spec/cf/cli_spec.rb
+++ b/spec/cf/cli_spec.rb
@@ -118,6 +118,27 @@ describe CF::CLI do
       end
     end
 
+    context "with a CFoundry authentication error when the force flag is set" do
+      let(:action) { proc { raise CFoundry::InvalidAuthToken.new("foo bar") } }
+      let(:asked) { false }
+      let(:inputs) { { :force => true } }
+
+      before do
+        $cf_asked_auth = asked
+      end
+
+      it "tells the user they are not authenticated" do
+        stub(context).invoke(:login)
+        subject
+        expect(stdout.string).to include "Invalid authentication token. Try logging in again with 'cf login'."
+      end
+
+      it "does not ask them to log in" do
+        dont_allow(context).invoke(:login)
+        subject
+      end
+    end
+
     context "with an arbitrary exception" do
       let(:action) { proc { raise "foo bar" } }
 


### PR DESCRIPTION
I am using cf through a shell script.
I noticed that despite using the --force flag there would still be an interactive prompt to login the user. That seems to go against the documentation. Also it is not consistent with cli.rb's method `check_logged_in`

Use case:

```
 cf logout
 cf --force apps
```

should not do an interactive login.
