### PR TITLE
do reset the env values when --reset is used

### DIFF
--- a/lib/manifests/plugin.rb
+++ b/lib/manifests/plugin.rb
@@ -99,6 +99,7 @@ class ManifestsPlugin < CF::App::Base
           a
         },
         :push_app => proc { |a|
+          setup_env(a, app_manifest) if input[:reset]
           setup_services(a, app_manifest)
           a
         }


### PR DESCRIPTION
When I use `cf push --reset` with a manifest I noticed that the environment variables were not re-applied as defined in the manifest.

This patch does apply the environment variables as defined in the manifest with a `cf push --reset`.

This PR was originally made against the vmc codebase in https://github.com/cloudfoundry/manifests-vmc-plugin/pull/2
@austinbv suggested I port it to cf.
