### PR TITLE
Display next command on new line

### DIFF
--- a/lib/cf/cli/space/create.rb
+++ b/lib/cf/cli/space/create.rb
@@ -38,7 +38,9 @@ module CF
         if input[:target]
           invoke :target, :organization => space.organization, :space => space
         else
-          line c("Space created! Use #{b("`cf switch-space #{space.name}`")} to target it.", :good)
+          line c("Space created!", :good)
+          line
+          line "#{b("cf switch-space #{space.name}")}    # targets new space"
         end
       end
 


### PR DESCRIPTION
This allows for triple-click to select the whole line for easy copy/paste
into terminal.

Usage:

```
$ bundle exec bin/cf.dev create-space
Name> test5

Creating space test5... OK
Adding you as a manager... OK
Adding you as a developer... OK
Space created!

cf switch-space test5    # targets new space
```
