### PR TITLE
Fix for disabling debug mode for an application.

### DIFF
--- a/lib/cf/cli/app/start.rb
+++ b/lib/cf/cli/app/start.rb
@@ -28,7 +28,7 @@ module CF::App
         stream_start_log(log) if log
         check_application(app)
 
-        if app.debug_mode && !quiet?
+        if !app.debug_mode.nil? && app.debug_mode != "none" && !quiet?
           line
           invoke :instances, :app => app
         end
@@ -64,14 +64,13 @@ module CF::App
 
     # set app debug mode, ensuring it's valid, and shutting it down
     def switch_mode(app, mode)
-      mode = nil if mode == "none"
       mode = "run" if mode == "" # no value given
 
       return false if app.debug == mode
 
-      if mode.nil?
+      if mode == "none"
         with_progress("Removing debug mode") do
-          app.debug = nil
+          app.debug = mode
           app.stop! if app.started?
         end
 

--- a/spec/cf/cli/app/start_spec.rb
+++ b/spec/cf/cli/app/start_spec.rb
@@ -235,7 +235,7 @@ module CF
             let(:mode) { "none" }
 
             it "removes the debug mode" do
-              expect { execute_start_app_with_mode }.to change { app.debug }.from("in_debug").to(nil)
+              expect { execute_start_app_with_mode }.to change { app.debug }.from("in_debug").to("none")
             end
           end
 


### PR DESCRIPTION
Currently it is not possible to turn off debug between cf and the cloud controller.

Since the api specs are not clear in this area I'm assuming in this patch that cloud controller is functioning correctly and that cf is wrong.  I've submitted a pull request to the cloud controller to test this api. https://github.com/cloudfoundry/cloud_controller_ng/pull/67

This is to fix cf so that it complies with the api cloud controller providing.
