### PR TITLE
add --find-if-exists to create-space and create-org

### DIFF
--- a/lib/cf/cli/populators/populator_methods.rb
+++ b/lib/cf/cli/populators/populator_methods.rb
@@ -11,7 +11,7 @@ module CF
 
       def populate_and_save!
         obj = get_object
-        info[type] = obj.guid
+        info[type] = obj.guid unless obj.nil?
         save_target_info(info)
         invalidate_client
 
@@ -48,9 +48,7 @@ module CF
         object_choices = choices
 
         if object_choices.empty?
-          raise CF::UserFriendlyError.new(
-            "There are no #{type}s. You may want to create one with #{c("create-#{type == :organization ? "org" : type}", :good)}."
-          )
+          with_progress("There are no #{type}s. You may want to create one with #{c("create-#{type == :organization ? "org" : type}", :good)}.") {}
         elsif object_choices.is_a?(String)
           raise CF::UserFriendlyError.new(object_choices)
         elsif object_choices.size == 1 && !input.interactive?(type)

--- a/lib/cf/cli/space/create.rb
+++ b/lib/cf/cli/space/create.rb
@@ -16,7 +16,6 @@ module CF
       input :developer, :desc => "Add yourself as developer", :default => true
       input :auditor, :desc => "Add yourself as auditor", :default => false
       input :find_if_exists, :desc => "Use an existing space if one already exists with the given name", :default => false
-
       def create_space
         space = client.space
         space.organization = org

--- a/spec/cf/cli/organization/create_spec.rb
+++ b/spec/cf/cli/organization/create_spec.rb
@@ -1,0 +1,121 @@
+require "spec_helper"
+
+module CF
+  module Organization
+    describe Create do
+      let(:client) { build(:client) }
+      before { stub_client_and_precondition }
+
+      describe "metadata" do
+        subject(:command) { Mothership.commands[:create_org] }
+
+        its(:description) { should == "Create an organization" }
+        it { expect(Mothership::Help.group(:organizations)).to include(command) }
+        its(:arguments) { should == [{type: :optional, value: nil, name: :name}] }
+
+        include_examples "inputs must have descriptions"
+      end
+
+      describe "running the command" do
+        let(:new_org) { build(:organization) }
+        let(:current_user) { build(:user) }
+
+        before do
+          client.stub(organization: new_org)
+          client.stub(current_user: current_user)
+
+          @command_args = ["create-org", new_org.name]
+        end
+
+        context "when the organization already exists" do
+          let(:existing_org) { build(:organization, name: new_org.name) }
+
+          before do
+            new_org.stub(:create!).and_raise(CFoundry::OrganizationNameTaken)
+          end
+
+          context "when --find-if-exists is given" do
+            before { @command_args << "--find-if-exists" }
+            before { client.stub(:organization_by_name).with(new_org.name).and_return(existing_org) }
+
+            context "when --target is given" do
+              before { @command_args << "--target" }
+
+              it "switches them to the existing organization" do
+                mock_invoke :target, organization: existing_org
+                cf @command_args
+              end
+            end
+
+            context "when --target is NOT given" do
+              it "does not actively switch to the existing organization" do
+                dont_allow_invoke :target
+                cf @command_args
+              end
+            end
+          end
+
+          context "when --find-if-exists is NOT given" do
+            before { @command_args << "--target" }
+
+            context "when --target is given" do
+              it "raises an exception" do
+                expect { cf @command_args }.to raise_error(CFoundry::OrganizationNameTaken)
+              end
+            end
+
+            context "when --target is NOT given" do
+              it "raises an exception" do
+                expect { cf @command_args }.to raise_error(CFoundry::OrganizationNameTaken)
+              end
+            end
+          end
+        end
+
+        context "when the organization DOES NOT already exist" do
+          before do
+            new_org.stub(:create!)
+          end
+
+          context "when --find-if-exists is given" do
+            before { @command_args << "--find-if-exists" }
+
+            context "when --target is given" do
+              before { @command_args << "--target" }
+
+              it "switches them to the new organization" do
+                mock_invoke :target, organization: new_org
+                cf @command_args
+              end
+            end
+
+            context "when --target is NOT given" do
+              it "does not actively switch to the existing organization" do
+                dont_allow_invoke :target
+                cf @command_args
+              end
+            end
+          end
+
+          context "when --find-if-exists is NOT given" do
+            context "when --target is given" do
+              before { @command_args << "--target" }
+
+              it "switches them to the new organization" do
+                mock_invoke :target, organization: new_org
+                cf @command_args
+              end
+            end
+
+            context "when --target is NOT given" do
+              it "does not actively switch to the existing organization" do
+                dont_allow_invoke :target
+                cf @command_args
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cf/cli/populators/organization_spec.rb
+++ b/spec/cf/cli/populators/organization_spec.rb
@@ -155,8 +155,9 @@ module CF
                 write_token_file({})
               end
 
-              it "tells the user to create one by raising a UserFriendlyError" do
-                expect { execute_populate_and_save }.to raise_error(CF::UserFriendlyError, "There are no organizations. You may want to create one with create-org.")
+              it "warns the user they should create one" do
+                execute_populate_and_save
+                expect(output).to say("There are no organizations. You may want to create one with create-org.")
               end
             end
 

--- a/spec/cf/cli/populators/space_spec.rb
+++ b/spec/cf/cli/populators/space_spec.rb
@@ -143,8 +143,9 @@ module CF
                 organization.stub(:spaces).and_return([])
               end
 
-              it "tells the user to create one by raising a UserFriendlyError" do
-                expect { execute_populate_and_save }.to raise_error(CF::UserFriendlyError, /There are no spaces/)
+              it "warns the user they should create one" do
+                execute_populate_and_save
+                expect(output).to say("There are no spaces. You may want to create one with create-space.")
               end
             end
           end

--- a/spec/cf/cli/space/create_spec.rb
+++ b/spec/cf/cli/space/create_spec.rb
@@ -21,8 +21,8 @@ module CF
           subject { command.arguments }
           it "has the correct argument order" do
             should eq([
-              {:type => :optional, :value => nil, :name => :name},
-              {:type => :optional, :value => nil, :name => :organization}
+              {type: :optional, value: nil, name: :name},
+              {type: :optional, value: nil, name: :organization}
             ])
           end
         end
@@ -30,33 +30,110 @@ module CF
 
       describe "running the command" do
         let(:new_space) { build(:space) }
-        let(:organization) { build(:organization, :spaces => [new_space]) }
 
         before do
-          client.stub(:space).and_return(new_space)
-          new_space.stub(:create!)
-          new_space.stub(:add_manager)
-          new_space.stub(:add_developer)
-          new_space.stub(:add_auditor)
-          CF::Populators::Organization.any_instance.stub(:populate_and_save!).and_return(organization)
-          CF::Populators::Organization.any_instance.stub(:choices).and_return([organization])
+          client.stub(space: new_space)
+          CF::Populators::Organization.any_instance.stub(populate_and_save!: organization)
+          CF::Populators::Organization.any_instance.stub(choices: [organization])
+
+          @command_args = ["create-space", new_space.name]
         end
 
-        context "when --target is given" do
-          subject { cf %W[create-space #{new_space.name} --target] }
+        context "when the space already exists" do
+          let(:existing_space) { build(:space, name: new_space.name) }
+          let(:organization) { build(:organization, spaces: [existing_space]) }
+          
+          before do
+            new_space.stub(:create!).and_raise(CFoundry::SpaceNameTaken)
+            existing_space.stub(:add_manager)
+            existing_space.stub(:add_developer)
+            existing_space.stub(:add_auditor)
+          end             
+          
+          context "when --find-if-exists is given" do
+            before { @command_args << "--find-if-exists" }
+            before { client.stub(:space_by_name).with(new_space.name).and_return(existing_space) }
 
-          it "switches them to the new space" do
-            mock_invoke :target, :organization => organization, :space => new_space
-            subject
+            context "when --target is given" do
+              before { @command_args << "--target" }
+
+              it "switches them to the existing space" do
+                mock_invoke :target, organization: organization, space: existing_space
+                cf @command_args
+              end
+            end
+
+            context "when --target is NOT given" do
+              it "tells the user how they can switch to the existing space" do
+                cf @command_args
+                expect(output).to say("Space already exists!\n\ncf switch-space #{existing_space.name}    # targets existing space")
+              end
+            end
+          end
+
+          context "when --find-if-exists is NOT given" do
+            before { @command_args << "--target" }
+
+            context "when --target is given" do
+              it "raises an exception" do
+                expect { cf @command_args }.to raise_error(CFoundry::SpaceNameTaken)
+              end
+            end
+
+            context "when --target is NOT given" do
+              it "raises an exception" do
+                expect { cf @command_args }.to raise_error(CFoundry::SpaceNameTaken)
+              end
+            end
           end
         end
 
-        context "when --target is NOT given" do
-          subject { cf %W[create-space #{new_space.name}] }
+        context "when the space DOES NOT already exist" do
+          let(:organization) { build(:organization, spaces: []) }
 
-          it "tells the user how they can switch to the new space" do
-            subject
-            expect(output).to say("Space created!\n\ncf switch-space #{new_space.name}    # targets new space")
+          before do
+            new_space.stub(:create!)
+            new_space.stub(:add_manager)
+            new_space.stub(:add_developer)
+            new_space.stub(:add_auditor)
+          end          
+          
+          context "when --find-if-exists is given" do
+            before { @command_args << "--find-if-exists" }
+
+            context "when --target is given" do
+              before { @command_args << "--target" }
+
+              it "switches them to the new space" do
+                mock_invoke :target, organization: organization, space: new_space
+                cf @command_args
+              end
+            end
+
+            context "when --target is NOT given" do
+              it "tells the user how they can switch to the new space" do
+                cf @command_args
+                expect(output).to say("Space created!\n\ncf switch-space #{new_space.name}    # targets new space")
+              end
+            end
+          end
+
+          context "when --find-if-exists is NOT given" do
+            context "when --target is given" do
+              before { @command_args << "--target" }
+
+              it "switches them to the new space" do
+                mock_invoke :target, organization: organization, space: new_space
+                cf @command_args
+              end
+            end
+
+            context "when --target is NOT given" do
+              it "tells the user how they can switch to the new space" do
+                cf @command_args
+                expect(output).to say("Space created!\n\ncf switch-space #{new_space.name}    # targets new space")
+              end
+            end
           end
         end
       end

--- a/spec/features/org_spec.rb
+++ b/spec/features/org_spec.rb
@@ -1,14 +1,9 @@
 require "spec_helper"
 
 if ENV["CF_V2_RUN_INTEGRATION"]
-  describe "creating and deleting orgs", :ruby19 => true do
-    before(:all) do
-      WebMock.allow_net_connect!
-    end
-
-    after(:all) do
-      WebMock.disable_net_connect!
-    end
+  describe "creating and deleting orgs", ruby19: true do
+    before(:all) { WebMock.allow_net_connect! }
+    after(:all) { WebMock.disable_net_connect! }
 
     let(:run_id) { TRAVIS_BUILD_ID.to_s + Time.new.to_f.to_s.gsub(".", "_") }
     let(:new_org_name) { "new-org-#{run_id}" }
@@ -25,27 +20,31 @@ if ENV["CF_V2_RUN_INTEGRATION"]
 
     it "can create and recursively delete an org" do
       BlueShell::Runner.run("cf create-org #{new_org_name}") do |runner|
-        runner.should say "Creating organization #{new_org_name}... OK"
-        runner.should say "Switching to organization #{new_org_name}... OK"
-        runner.should say "There are no spaces. You may want to create one with create-space."
+        expect(runner).to say "Creating organization #{new_org_name}... OK"
+        expect(runner).to say "Switching to organization #{new_org_name}... OK"
+        expect(runner).to say "There are no spaces. You may want to create one with create-space."
       end
 
       BlueShell::Runner.run("cf create-space new-space") do |runner|
-        runner.should say "Creating space new-space... OK"
+        expect(runner).to say "Creating space new-space... OK"
       end
 
-      # pending until cc change 442f08e72c0808baf85b948a8b56e58f025edf72 is on a1
-      #BlueShell::Runner.run("cf delete-org #{new_org_name} --force") do |runner|
-      #  runner.should say "If you want to delete the organization along with all dependent objects, rerun the command with the '--recursive' flag."
-      #end
+      # TODO: pending until cc change 442f08e72c0808baf85b948a8b56e58f025edf72 is on a1
+      #
+      # BlueShell::Runner.run("cf delete-org #{new_org_name} --force") do |runner|
+      #   expect(runner).to say "If you want to delete the organization along with" +
+      #     " all dependent objects, rerun the command with the '--recursive' flag."
+      # end
 
       BlueShell::Runner.run("cf delete-org #{new_org_name} --force --recursive") do |runner|
-        runner.should say("Deleting organization #{new_org_name}... OK")
+        expect(runner).to say "Deleting organization #{new_org_name}... OK", 15
       end
 
       BlueShell::Runner.run("cf orgs") do |runner|
-        runner.should_not say("#{new_org_name}")
+        expect(runner).to_not say new_org_name
       end
     end
   end
+else
+  $stderr.puts 'Skipping v2 integration specs; please provide necessary environment variables'
 end

--- a/spec/features/switching_targets_spec.rb
+++ b/spec/features/switching_targets_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 if ENV['CF_V2_RUN_INTEGRATION']
-  describe 'A new user tries to use CF against v2 production', :ruby19 => true do
+  describe 'A new user tries to use CF against v2 production', ruby19: true do
 
     let(:target) { ENV['CF_V2_TEST_TARGET'] }
     let(:space) { ENV['CF_V2_TEST_SPACE'] }
@@ -14,6 +14,7 @@ if ENV['CF_V2_RUN_INTEGRATION']
     before do
       Interact::Progress::Dots.start!
     end
+
     after do
       logout
       Interact::Progress::Dots.stop!
@@ -37,23 +38,23 @@ if ENV['CF_V2_RUN_INTEGRATION']
         login
 
         BlueShell::Runner.run("#{cf_bin} target -o #{organization_2}") do |runner|
-          expect(runner).to say("Switching to organization #{organization_2}")
-          expect(runner).to say("Space>")
+          expect(runner).to say "Switching to organization #{organization_2}"
+          expect(runner).to say "Space>"
           runner.send_keys space_2
 
           expect(runner).to say(/Switching to space #{space_2}/)
 
-          runner.wait_for_exit
+          runner.wait_for_exit 15
         end
 
         BlueShell::Runner.run("#{cf_bin} target -s #{space}") do |runner|
           expect(runner).to say("Switching to space #{space}")
-          runner.wait_for_exit(15)
+          runner.wait_for_exit 15
         end
 
         BlueShell::Runner.run("#{cf_bin} target -s #{space_2}") do |runner|
           expect(runner).to say("Switching to space #{space_2}")
-          runner.wait_for_exit(15)
+          runner.wait_for_exit 15
         end
       end
     end

--- a/spec/support/features_helper.rb
+++ b/spec/support/features_helper.rb
@@ -24,7 +24,7 @@ module FeaturesHelper
   def set_target
     target = ENV['CF_V2_TEST_TARGET']
     BlueShell::Runner.run("#{cf_bin} target #{target}") do |runner|
-      runner.wait_for_exit(20)
+      runner.wait_for_exit 20
     end
   end
 
@@ -49,8 +49,8 @@ module FeaturesHelper
         expect(runner).to say "Domain>"
         runner.send_keys "1"
 
-        expect(runner).to say(/Creating route #{deployed_app_name}\..*\.\.\. OK/)
-        expect(runner).to say(/Binding #{deployed_app_name}\..* to #{deployed_app_name}\.\.\. OK/)
+        expect(runner).to say /Creating route #{deployed_app_name}\..*\.\.\. OK/
+        expect(runner).to say /Binding #{deployed_app_name}\..* to #{deployed_app_name}\.\.\. OK/
 
         expect(runner).to say "Create services for application?> n"
         runner.send_return
@@ -59,7 +59,7 @@ module FeaturesHelper
           runner.send_return
         end
 
-        runner.wait_for_exit
+        runner.wait_for_exit 15
       end
     end
   end


### PR DESCRIPTION
Add a `--find-if-exists` option to `cf create-space` and `cf create-org`, which will not blow up if a user tries to create a space in an org with a name that already exists, or tries to create an org with a name that already exists.

The motivation is to allow people to write more idempotent scripts that may need to shell out and invoke `cf`.

-- @Amit-PivotalLabs + @jfoley 
