### PR TITLE
remove duplicate directory in config_file_path

### DIFF
--- a/lib/tunnel/README.md
+++ b/lib/tunnel/README.md
@@ -15,7 +15,7 @@ gem install tunnel-cf-plugin
 tunnel [INSTANCE] [CLIENT]        Create a local tunnel to a service.
 ```
 
-You can add support for other command-line clients by providing a `~/.cf/clients.yml` file with the following format:
+You can add support for other command-line clients by providing a `~/.cf/tunnel-clients.yml` file with the following format:
 
 ```yaml
 service_name:

--- a/lib/tunnel/plugin.rb
+++ b/lib/tunnel/plugin.rb
@@ -80,7 +80,7 @@ module CFTunnelPlugin
     private
 
     def config_file_path
-      File.expand_path("#{CF::CONFIG_DIR}/.cf/#{CLIENTS_FILE}")
+      File.expand_path("#{CF::CONFIG_DIR}/#{CLIENTS_FILE}")
     end
 
     def display_tunnel_connection_info(info)

--- a/spec/tunnel/plugin_spec.rb
+++ b/spec/tunnel/plugin_spec.rb
@@ -4,7 +4,7 @@ describe CFTunnelPlugin::Tunnel do
   describe "#tunnel_clients" do
     context "when the user has a custom clients.yml in their cf directory" do
       it "overrides the default client config with the user's customizations" do
-        subject.stub(:config_file_path) { "#{SPEC_ROOT}/fixtures/fake_home_dirs/with_custom_clients/.cf/#{CFTunnelPlugin::Tunnel::CLIENTS_FILE}" }
+        CF::CONFIG_DIR = "#{SPEC_ROOT}/fixtures/fake_home_dirs/with_custom_clients/.cf"
 
         expect(subject.tunnel_clients["postgresql"]).to eq({
           "psql" => {


### PR DESCRIPTION
When trying to add custom tunnel clients, I came accross two errors:

1) I found out that the file that cf uses to check for custom clients is not `clients.yml` but `tunnel-clients.yml`. So I updated the readme accordingly. Can be verified [here](https://github.com/cloudfoundry/cf/blob/master/lib/tunnel/plugin.rb#L6)

2) I found a duplication in the `config_file_path` method. `CF::CONFIG_DIR` returns `.cf` as can be verified [here](https://github.com/cloudfoundry/cf/blob/master/lib/cf/constants.rb#L2). I removed the hardcoded `.cf` from the path.
