### PR TITLE
Increase console connection timeout

### DIFF
--- a/lib/console/console.rb
+++ b/lib/console/console.rb
@@ -181,7 +181,7 @@ class CFConsole < CFTunnel
     Net::Telnet.new(
       "Port" => @port,
       "Prompt" => /[$%#>] \z|Login failed/n,
-      "Timeout" => 30,
+      "Timeout" => 90,
       "FailEOF" => true)
   end
 end


### PR DESCRIPTION
We experienced that for some applications (even from some of our customers) the rails console needs awhile until its up. So we increased the timeout to make it possible to get a console connection to these applications.
