### PR TITLE
Fix a service provider nil equivalency bug.

### DIFF
--- a/lib/manifests/manifests.rb
+++ b/lib/manifests/manifests.rb
@@ -309,7 +309,7 @@ module CFManifests
           offering = offerings.find { |o|
             o.label == (svc[:label] || svc[:type] || svc[:vendor]) &&
               (!svc[:version] || o.version == svc[:version]) &&
-              (o.provider == (svc[:provider] || "core"))
+              (o.provider == svc[:provider] || (svc[:provider].nil? && o.provider == "core"))
           }
 
           fail "Unknown service offering: #{svc.inspect}." unless offering


### PR DESCRIPTION
Fix a nil equivalency bug that was preventing users from repushing an app after deleting it, when the service provider is nil.

Signed-off-by: Ryan Tang ryantang@pivotallabs.com
