### PR TITLE
Fix token issuer logging

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 5.4.6
+
+Require a newer version of cfoundry in order to resolve a trace logging bug where some trace info was accidentally sent to STDOUT instead of STDERR. @moonmaster9000, @jimmida, @xchoi

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    cf (5.4.5)
+    cf (5.4.6)
       addressable
       caldecott-client (~> 0.0.2)
-      cfoundry (~> 4.7.1.rc1)
+      cfoundry (~> 4.7.2.rc1)
       interact (>= 0.5)
       json_pure
       mothership (>= 0.5.1)
@@ -36,11 +36,11 @@ GEM
     builder (3.1.4)
     caldecott-client (0.0.2)
       multi_json (~> 1.3)
-    cf-uaa-lib (2.0.0)
+    cf-uaa-lib (2.0.1)
       multi_json
-    cfoundry (4.7.1.rc1)
+    cfoundry (4.7.2.rc1)
       activemodel (>= 3.2.13, < 5.0.0)
-      cf-uaa-lib (~> 2.0.0)
+      cf-uaa-lib (~> 2.0.1)
       multi_json (~> 1.7)
       multipart-post (~> 1.1)
       rubyzip (~> 0.9)

--- a/cf.gemspec
+++ b/cf.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "addressable"
   s.add_runtime_dependency "caldecott-client", "~> 0.0.2"
-  s.add_runtime_dependency "cfoundry", "~> 4.7.2"
+  s.add_runtime_dependency "cfoundry", "~> 4.7.2.rc1"
   s.add_runtime_dependency "interact", ">= 0.5"
   s.add_runtime_dependency "json_pure"
   s.add_runtime_dependency "mothership", ">= 0.5.1"

--- a/cf.gemspec
+++ b/cf.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "addressable"
   s.add_runtime_dependency "caldecott-client", "~> 0.0.2"
-  s.add_runtime_dependency "cfoundry", "~> 4.7.1.rc1"
+  s.add_runtime_dependency "cfoundry", "~> 4.7.2"
   s.add_runtime_dependency "interact", ">= 0.5"
   s.add_runtime_dependency "json_pure"
   s.add_runtime_dependency "mothership", ">= 0.5.1"

--- a/lib/cf/version.rb
+++ b/lib/cf/version.rb
@@ -1,3 +1,3 @@
 module CF
-  VERSION = "5.4.5".freeze
+  VERSION = "5.4.6".freeze
 end


### PR DESCRIPTION
There was an issue with token issuer logging in the cf-uaa-lib. This change just bumps versions of the downstream dependencies. This pull request will start passing once the other pull requests are merged and the new versions of those gems are released: 

https://github.com/cloudfoundry/cf-uaa-lib/pull/7
https://github.com/cloudfoundry/cfoundry/pull/27
