### PR TITLE
change the APP_CHECK_LIMIT

### DIFF
--- a/lib/cf/cli/app/start.rb
+++ b/lib/cf/cli/app/start.rb
@@ -2,7 +2,7 @@ require "cf/cli/app/base"
 
 module CF::App
   class Start < Base
-    APP_CHECK_LIMIT = 60
+    APP_CHECK_LIMIT = 900
 
     desc "Start an application"
     group :apps, :manage


### PR DESCRIPTION
the default stageing timeout is 900, the APP_CHECK_LIMIT need  to be 900,
because when we push app using cf, our stageing process is slow,it always send "staged failed" message.
