### PR TITLE
Warn person who has installed this gem about deprecation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cf (5.4.7)
+    cf (5.4.8)
       addressable
       caldecott-client (~> 0.0.2)
       cfoundry (~> 4.7.2.rc1)
@@ -146,3 +146,6 @@ DEPENDENCIES
   rspec-instafail (~> 0.2.4)
   sinatra
   webmock
+
+BUNDLED WITH
+   1.13.6

--- a/cf.gemspec
+++ b/cf.gemspec
@@ -48,4 +48,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-instafail", "~> 0.2.4"
   s.add_development_dependency "sinatra"
   s.add_development_dependency "webmock"
+
+  s.post_install_message = <<-NOTICE.strip
+    ** This gem has been deprecated. Please read README of this project -- https://github.com/cloudfoundry-attic/cf. **
+  NOTICE
 end

--- a/lib/cf/version.rb
+++ b/lib/cf/version.rb
@@ -1,3 +1,3 @@
 module CF
-  VERSION = "5.4.7".freeze
+  VERSION = '5.4.8'.freeze
 end


### PR DESCRIPTION
Today I found info about installing Cloud Foundry as a Gem so I took this path since in the official documentation was referencing to some OSX installer without link to it.

Hope this will help somebody